### PR TITLE
Fix hard coded python version in CI, remove broken versions

### DIFF
--- a/.github/workflows/python-test-conda-external.yml
+++ b/.github/workflows/python-test-conda-external.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6.12, 3.7.9]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -30,10 +30,6 @@ jobs:
       working-directory: ./fred-tools/
       run: |
         ./post.runner
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Set conda package directory
       run: |
         mkdir /tmp/condapkgs
@@ -44,7 +40,7 @@ jobs:
         echo "PATH=$PATH"
     - name: Install test dependencies and dependencies that pip would build from source
       run: |
-        $CONDA/bin/conda create -p /tmp/condaenv -c conda-forge -c bioconda 'python==3.7' biopython svmlight==6.02 'tensorflow==2.0.0' 'markdown==3.3.2' coincbc
+        $CONDA/bin/conda create -p /tmp/condaenv -c conda-forge -c bioconda python==${{ matrix.python-version }} biopython svmlight==6.02 'tensorflow==2.0.0' 'markdown==3.3.2' coincbc
         export PATH="/tmp/condaenv/bin:$PATH"
     - name: Activate conda environment
       run: |

--- a/.github/workflows/python-test-conda.yml
+++ b/.github/workflows/python-test-conda.yml
@@ -11,22 +11,18 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6.12, 3.7.9]
     runs-on: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Set conda package directory
       run: |
         mkdir /tmp/condapkgs
         echo "CONDA_PKGS_DIRS=/tmp/condapkgs" >> $GITHUB_ENV
     - name: Install test dependencies and dependencies that pip would build from source
       run: |
-        $CONDA/bin/conda create -p /tmp/condaenv -c conda-forge -c bioconda 'python==3.7' biopython svmlight==6.02 'tensorflow==2.0.0' 'markdown==3.3.2' coincbc
+        $CONDA/bin/conda create -p /tmp/condaenv -c conda-forge -c bioconda python==${{ matrix.python-version }} biopython svmlight==6.02 'tensorflow==2.0.0' 'markdown==3.3.2' coincbc
         export PATH="/tmp/condaenv/bin:$PATH"
     - name: Activate conda environment
       run: |


### PR DESCRIPTION
The python version matrix in the github action did not affect the python version installed in the conda environment. After fixing this I found that without additional changes to the installation routine the epytope / FRED-2 installation fails on 3.5 and 3.8, so I removed them for now.