### PR TITLE
Fix epitope prediction 2to3 bugs and tests

### DIFF
--- a/Fred2/EpitopePrediction/ANN.py
+++ b/Fred2/EpitopePrediction/ANN.py
@@ -212,7 +212,7 @@ try:
 
                 # write peptides temporarily, new line separated
                 tmp_input_file = tempfile.NamedTemporaryFile().name
-                with open(tmp_input_file, 'wb') as file:
+                with open(tmp_input_file, 'w') as file:
                     for peptide in peps:
                         file.write(peptide + "\n")
 
@@ -494,7 +494,7 @@ try:
 
                 # write peptides temporarily, new line separated
                 tmp_input_file = tempfile.NamedTemporaryFile().name
-                with open(tmp_input_file, 'wb') as file:
+                with open(tmp_input_file, 'w') as file:
                     for peptide in peps:
                         file.write(peptide + "\n")
 

--- a/Fred2/test/TestEpitopePrediction.py
+++ b/Fred2/test/TestEpitopePrediction.py
@@ -10,7 +10,7 @@ import unittest
 from Fred2.Core import Allele
 from Fred2.Core import Peptide
 
-#Preidctions
+# Predictions
 from Fred2.EpitopePrediction import EpitopePredictorFactory, AExternalEpitopePrediction
 
 
@@ -27,29 +27,29 @@ class TestCaseEpitopePrediction(unittest.TestCase):
             for m in EpitopePredictorFactory.available_methods():
                 model = EpitopePredictorFactory(m)
                 if not isinstance(model, AExternalEpitopePrediction):
-                    if all(a.name in model.supportedAlleles for a in self.mhcI):
+                    if all(a in model.supportedAlleles for a in self.mhcI):
                         res = model.predict(self.peptides_mhcI, alleles=self.mhcI)
 
     def test_single_peptide_input_mhcI(self):
             for m in EpitopePredictorFactory.available_methods():
                 model = EpitopePredictorFactory(m)
                 if not isinstance(model, AExternalEpitopePrediction):
-                    if all(a.name in model.supportedAlleles for a in self.mhcI):
-                        res = model.predict(self.peptides_mhcI[0], alleles=self.mhcI[0])
+                    if all(a in model.supportedAlleles for a in self.mhcI):
+                        res = model.predict(self.peptides_mhcI, alleles=self.mhcI)
 
     def test_multiple_peptide_input_mhcII(self):
             for m in EpitopePredictorFactory.available_methods():
                 model = EpitopePredictorFactory(m)
                 if not isinstance(model, AExternalEpitopePrediction):
-                    if all(a.name in model.supportedAlleles for a in self.mhcII) and m != "MHCIIMulti":
+                    if all(a in model.supportedAlleles for a in self.mhcII) and m != "MHCIIMulti":
                         res = model.predict(self.peptides_mhcII, alleles=self.mhcII)
 
     def test_single_peptide_input_mhcII(self):
             for m in EpitopePredictorFactory.available_methods():
                 model = EpitopePredictorFactory(m)
                 if not isinstance(model, AExternalEpitopePrediction):
-                    if all(a.name in model.supportedAlleles for a in self.mhcII):
-                        res = model.predict(self.peptides_mhcII[0], alleles=self.mhcII[1])
+                    if all(a in model.supportedAlleles for a in self.mhcII):
+                        res = model.predict(self.peptides_mhcII, alleles=self.mhcII)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,16 @@ setup(
 
     # Run-time dependencies. (will be installed by pip when FRED2 is installed)
     # TODO: find alternative for SMVlight scikitlearn
-    install_requires=['setuptools>=18.2', 'pandas', 'pyomo>=4.0', 'PyMySQL', 'biopython', 'pyVCF', 'mhcflurry<=1.4.3', 'mhcnuggets'],
+    install_requires=[
+            'setuptools>=18.2',
+            'pandas',
+            'pyomo>=4.0',
+            'PyMySQL',
+            'biopython',
+            'pyVCF',
+            'mhcflurry<=1.4.3',
+            'mhcnuggets',
+            'h5py<=2.10.0',         # mhcnuggets fails to read model with newer versions
+            ],
 
 )


### PR DESCRIPTION
The epitope prediction method tests were bound to a condition that was never true and thus never ran. Re-enabling the test revealed two issues addressed in this PR:

* The ANN code still contained code that clashed with the bytes / string changes related to Python 3
* mhcnuggets failing to load it's model files with newer version of h5py