### PR TITLE
Fix Invalid subprocess handling and mhcflurry polluting stdout

### DIFF
--- a/Fred2/EpitopePrediction/ANN.py
+++ b/Fred2/EpitopePrediction/ANN.py
@@ -752,10 +752,15 @@ try:
             alleles = self.convert_alleles(alleles)
 
             # test mhcflurry models are available => download if not
-            p = subprocess.Popen(['mhcflurry-downloads', 'path', 'models_class1'],
-                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p = subprocess.call(['mhcflurry-downloads', 'path', 'models_class1'],
+                                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             if p is not 0:
-                subprocess.call(['mhcflurry-downloads', 'fetch', 'models_class1'])
+                logging.warn("mhcflurry models must be downloaded, as they were not found locally.")
+                cp = subprocess.run(['mhcflurry-downloads', 'fetch', 'models_class1'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                if cp.returncode != 0:
+                    for line in cp.stdout.decode().splitlines():
+                        logging.error(line)
+                    raise RuntimeError("mhcflurry failed to download model file")
 
             # load model
             predictor = Class1AffinityPredictor.load()


### PR DESCRIPTION
This PR addresses the following issues in the mhcflurry bindings:

* Broken use of `subprocess.Popen()` - `Popen()` doesn't block and the result is not properly evaluated. This lead to `fetch` being always triggered, however, it contains it's own checking so it didn't actually download anything if the model is present locally.
* There was no error handling for the `fetch` call
* The `fetch` call polluted stdout, the output is now captured and only logged if an error occurred.