### PR TITLE
Add keras dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,7 @@ setup(
             'pyVCF',
             'mhcflurry<=1.4.3',
             'mhcnuggets',
+            'keras<=2.3.1',         # legacy tensorflow required by mhcnuggets resolves to incompatible keras version
             'h5py<=2.10.0',         # mhcnuggets fails to read model with newer versions
             ],
 


### PR DESCRIPTION
legacy tensorflow required by mhcnuggets resolves to incompatible keras version