### PR TITLE
Fix protobuf version for tests, prepare docs for 3.1.0 release

### DIFF
--- a/.github/workflows/python-test-conda-external.yml
+++ b/.github/workflows/python-test-conda-external.yml
@@ -40,7 +40,7 @@ jobs:
         echo "PATH=$PATH"
     - name: Set up Python ${{ matrix.python-version }}
       run: |
-        $CONDA/bin/conda create -p /tmp/condaenv python==${{ matrix.python-version }}'.*' setuptools"==52.0" protobuf"==3.20.1"
+        $CONDA/bin/conda create -p /tmp/condaenv python==${{ matrix.python-version }}'.*' setuptools"==52.0" protobuf"<=3.20.1"
     - name: Activate conda environment
       run: |
         echo "/tmp/condaenv/bin" >> $GITHUB_PATH

--- a/.github/workflows/python-test-conda-external.yml
+++ b/.github/workflows/python-test-conda-external.yml
@@ -40,7 +40,7 @@ jobs:
         echo "PATH=$PATH"
     - name: Set up Python ${{ matrix.python-version }}
       run: |
-        $CONDA/bin/conda create -p /tmp/condaenv python==${{ matrix.python-version }}'.*' setuptools"==52.0"
+        $CONDA/bin/conda create -p /tmp/condaenv python==${{ matrix.python-version }}'.*' setuptools"==52.0" protobuf"==3.20.1"
     - name: Activate conda environment
       run: |
         echo "/tmp/condaenv/bin" >> $GITHUB_PATH

--- a/.github/workflows/python-test-conda.yml
+++ b/.github/workflows/python-test-conda.yml
@@ -22,7 +22,7 @@ jobs:
         echo "CONDA_PKGS_DIRS=/tmp/condapkgs" >> $GITHUB_ENV
     - name: Set up Python ${{ matrix.python-version }}
       run: |
-        $CONDA/bin/conda create -p /tmp/condaenv python==${{ matrix.python-version }}'.*' setuptools"==52.0"
+        $CONDA/bin/conda create -p /tmp/condaenv python==${{ matrix.python-version }}'.*' setuptools"==52.0" protobuf"==3.20.1"
     - name: Activate conda environment
       run: |
         echo "/tmp/condaenv/bin" >> $GITHUB_PATH

--- a/.github/workflows/python-test-conda.yml
+++ b/.github/workflows/python-test-conda.yml
@@ -22,7 +22,7 @@ jobs:
         echo "CONDA_PKGS_DIRS=/tmp/condapkgs" >> $GITHUB_ENV
     - name: Set up Python ${{ matrix.python-version }}
       run: |
-        $CONDA/bin/conda create -p /tmp/condaenv python==${{ matrix.python-version }}'.*' setuptools"==52.0" protobuf"==3.20.1"
+        $CONDA/bin/conda create -p /tmp/condaenv python==${{ matrix.python-version }}'.*' setuptools"==52.0" protobuf"<=3.20.1"
     - name: Activate conda environment
       run: |
         echo "/tmp/condaenv/bin" >> $GITHUB_PATH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,20 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v3.1.0 - 2022-06-01
+## v3.1.0dev - 2022-06-01
 
 ### `Added`
 
-- [#58](https://github.com/KohlbacherLab/epytope/pull/58) - Add check for `BioMart` transcript sequence availability
-- [#59](https://github.com/KohlbacherLab/epytope/pull/59) - Add interface for `netMHCpan 4.1`
+- [#58](https://github.com/KohlbacherLab/epytope/pull/58) - Add check for `BioMart` transcript sequence availability [#55](https://github.com/KohlbacherLab/epytope/issues/55)
+- [#59](https://github.com/KohlbacherLab/epytope/pull/59) - Add interface for `NetMHCpan 4.1`
 
 ### `Changed`
 
-- [#62](https://github.com/KohlbacherLab/epytope/pull/62) - Update supportedAlleles of `syfpeithi`
+- [#62](https://github.com/KohlbacherLab/epytope/pull/62) - Update the supported alleles of `syfpeithi` [#60](https://github.com/KohlbacherLab/epytope/issues/60)
 
 ### `Fixed`
 
-- [#53](https://github.com/KohlbacherLab/epytope/pull/53) - Fix `ANN` predictor results
+- [#53](https://github.com/KohlbacherLab/epytope/pull/53) - Fix `ANN` predictor results [#52](https://github.com/KohlbacherLab/epytope/issues/52)
 
 ## v3.0.0 - 2022-01-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v3.1.0 - 2022-06-01
+
+### `Added`
+
+- [#58](https://github.com/KohlbacherLab/epytope/pull/58) - Add check for `BioMart` transcript sequence availability
+- [#59](https://github.com/KohlbacherLab/epytope/pull/59) - Add interface for `netMHCpan 4.1`
+
+### `Changed`
+
+- [#62](https://github.com/KohlbacherLab/epytope/pull/62) - Update supportedAlleles of `syfpeithi`
+
+### `Fixed`
+
+- [#53](https://github.com/KohlbacherLab/epytope/pull/53) - Fix `ANN` predictor results
+
 ## v3.0.0 - 2022-01-26
 
 Initial release of `epytope`. `epytope` is the successor project of [`FRED2`](https://github.com/FRED-2/Fred2), which was renamed to a more versioning friendly base name.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Currently **epytope** provides implementations of several prediction methods or 
   - [MHCflurry](https://pubmed.ncbi.nlm.nih.gov/29960884/) 1.2.2, 1.4.3
   - [NetMHC](https://pubmed.ncbi.nlm.nih.gov/26515819/) 3.0, 3.4, 4.0
   - [NetMHCII](https://pubmed.ncbi.nlm.nih.gov/29315598/) 2.2, 2.3
-  - [NetMHCpan](https://pubmed.ncbi.nlm.nih.gov/28978689/) 2.4, 2.8, 3.0, 4.0
+  - [NetMHCpan](https://pubmed.ncbi.nlm.nih.gov/28978689/) 2.4, 2.8, 3.0, 4.0, 4.1
   - [NetMHCIIpan](https://pubmed.ncbi.nlm.nih.gov/32406916/) 3.0, 3.1, 4.0
   - [PickPocket](https://pubmed.ncbi.nlm.nih.gov/19297351/) 1.1
   - [NetCTLpan](https://pubmed.ncbi.nlm.nih.gov/20379710/) 1.1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Tests](https://github.com/KohlbacherLab/epytope/actions/workflows/python-test-conda.yml/badge.svg)
 ![Tests external](https://github.com/KohlbacherLab/epytope/actions/workflows/python-test-conda-external.yml/badge.svg)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
-[![Anaconda-Server Badge](https://anaconda.org/bioconda/fred2/badges/installer/conda.svg)](https://conda.anaconda.org/bioconda)
+[![Anaconda-Server Badge](https://anaconda.org/bioconda/epytope/badges/installer/conda.svg)](https://conda.anaconda.org/bioconda)
 
 Copyright 2014 by Benjamin Schuber,  Mathias Walzer, Philipp Brachvogel, Andras Szolek, Christopher Mohr, and Oliver Kohlbacher
 
@@ -71,7 +71,7 @@ Currently **epytope** provides implementations of several prediction methods or 
 
 ## Getting Started
 
-Users and developers should start by reading our [wiki](https://github.com/KohlbacherLab/epytope/wiki) and [IPython tutorials](https://github.com/KohlbacherLab/epytope/tree/master/epytope/tutorials). A reference documentation is also available [online](http://fred2.readthedocs.org/en/latest/).
+Users and developers should start by reading our [wiki](https://github.com/KohlbacherLab/epytope/wiki) and [IPython tutorials](https://github.com/KohlbacherLab/epytope/tree/master/epytope/tutorials). A reference documentation is also available [online](http://epytope.readthedocs.org/en/latest/).
 
 ## How to Cite
 

--- a/epytope/doc/conf.py
+++ b/epytope/doc/conf.py
@@ -269,7 +269,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'eptyope', 'epytope Documentation',
+    (master_doc, 'epytope', 'epytope Documentation',
      [author], 1)
 ]
 

--- a/epytope/doc/conf.py
+++ b/epytope/doc/conf.py
@@ -269,7 +269,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'fred2', 'epytope Documentation',
+    (master_doc, 'eptyope', 'epytope Documentation',
      [author], 1)
 ]
 

--- a/epytope/tutorials/GeneratorUsage.ipynb
+++ b/epytope/tutorials/GeneratorUsage.ipynb
@@ -192,7 +192,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/antonia/PycharmProjects/Kfred/epytope/Core/Generator.py:57: UserWarning: For NM_001190266 bp does not match ref of assigned variant Variant(g.234183368A>G). Pos 645, var ref A, seq ref C \n",
+      "epytope/Core/Generator.py:57: UserWarning: For NM_001190266 bp does not match ref of assigned variant Variant(g.234183368A>G). Pos 645, var ref A, seq ref C \n",
       "  seq[pos]))\n"
      ]
     },
@@ -277,7 +277,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/antonia/opt/miniconda3/envs/epy/lib/python3.7/site-packages/Bio/Seq.py:2338: BiopythonWarning: Partial codon, len(sequence) not a multiple of three. Explicitly trim the sequence or add trailing N before translation. This may become an error in future.\n",
+      "/opt/miniconda3/envs/epy/lib/python3.7/site-packages/Bio/Seq.py:2338: BiopythonWarning: Partial codon, len(sequence) not a multiple of three. Explicitly trim the sequence or add trailing N before translation. This may become an error in future.\n",
       "  BiopythonWarning,\n"
      ]
     }

--- a/setup.py
+++ b/setup.py
@@ -140,6 +140,7 @@ setup(
             'mhcnuggets',
             'keras<=2.3.1',         # legacy tensorflow required by mhcnuggets resolves to incompatible keras version
             'h5py<=2.10.0',         # mhcnuggets fails to read model with newer versions
+            'protobuf==3.20.1'      # https://github.com/protocolbuffers/protobuf/issues/10051
             ],
 
 )

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,6 @@ setup(
             'mhcnuggets',
             'keras<=2.3.1',         # legacy tensorflow required by mhcnuggets resolves to incompatible keras version
             'h5py<=2.10.0',         # mhcnuggets fails to read model with newer versions
-            'protobuf==3.20.1'      # https://github.com/protocolbuffers/protobuf/issues/10051
             ],
 
 )


### PR DESCRIPTION
- Some changes/updates to the documentation before the release.
- Fix `protobuf` version to fix tests. This is necessary due to changes in the library. 