### PR TITLE
Update pypi-publish.yml

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   pypi-publish:
     name: Publish tagged release on PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - name: Install utilities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v3.3.1 - 2023-03-24
+## v3.3.1 - 2023-04-25
 
 ### `Added`
 


### PR DESCRIPTION
ubuntu 18 is not supported anymore in github workflows

https://github.com/actions/runner-images/issues/6002

We need to update in order to publish automatically to pypi