### PR TITLE
Update pypi-publish.yml

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Install utilities
-      run: sudo apt-get install -y mmv
     - name: Set up Python 3.7
       uses: actions/setup-python@v4
       with:
@@ -30,12 +28,6 @@ jobs:
         --wheel
         --outdir dist/
         .
-    - name: Create timestamp
-      run: echo timestamp=$(date +%s) >> $GITHUB_ENV
-    - name: Rename built files to include timestamp
-      run: |
-        mmv -v dist/'*.*.*-*' dist/'#1.#2.#3-'$timestamp'-#4'
-        mmv -v dist/'*.tar.gz' dist/'#1-'$timestamp.tar.gz
     - name: Publish distribution package to PyPI (test)
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -9,7 +9,7 @@ jobs:
     name: Publish tagged release on PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Install utilities
       run: sudo apt-get install -y mmv
     - name: Set up Python 3.7
@@ -37,11 +37,11 @@ jobs:
         mmv -v dist/'*.*.*-*' dist/'#1.#2.#3-'$timestamp'-#4'
         mmv -v dist/'*.tar.gz' dist/'#1-'$timestamp.tar.gz
     - name: Publish distribution package to PyPI (test)
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution package to PyPI (production)
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Warning after release:

>Publish tagged release on PyPI
Input 'password' has been deprecated with message: UNSUPPORTED GITHUB ACTION VERSION You are using `pypa/gh-action-pypi-publish@master`. The `master` branch of this project has been sunset and will not receive any updates, not even security bug fixes. Please, make sure to use a supported version. If you want to pin to v1 major version, use `pypa/gh-action-pypi-publish@release/v1`. If you feel adventurous, you may opt to use use `pypa/gh-action-pypi-publish@unstable/v1` instead. A more general recommendation is to pin to exact tags or commit SHAs. Please also consider migrading your setup to use secretless publishing: https://github.com/marketplace/actions/pypi-publish#trusted-publishing

Adjusted according to https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/