### PR TITLE
Switch PyPI publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -8,6 +8,8 @@ jobs:
   pypi-publish:
     name: Publish tagged release on PyPI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.11
@@ -15,25 +17,8 @@ jobs:
       with:
         python-version: '3.11'
     - name: Install pypa/build
-      run: >-
-        python -m
-        pip install
-        build
-        --user
+      run: python -m pip install build --user
     - name: Build a binary wheel and a source tarball
-      run: >-
-        python -m
-        build
-        --sdist
-        --wheel
-        --outdir dist/
-        .
-    - name: Publish distribution package to PyPI (test)
+      run: python -m build --sdist --wheel --outdir dist/ .
+    - name: Publish distribution package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-    - name: Publish distribution package to PyPI (production)
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
# Stale

Needs PyPI changes by codeowner

## Summary

- Replaces API token-based PyPI publishing with OIDC trusted publishing
- Removes dependency on `PYPI_API_TOKEN` and `TEST_PYPI_API_TOKEN` secrets
- Removes test PyPI step (was a potential blocker for production publishes)

**Prerequisite:** A repo maintainer needs to add the trusted publisher on https://pypi.org/manage/project/epytope/settings/publishing/ with owner `KohlbacherLab`, repo `epytope`, workflow `pypi-publish.yml`.

## Test plan

- [ ] Verify trusted publisher is configured on PyPI
- [ ] Create a test release and confirm package is published