### PR TITLE
Switch PyPI publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -8,6 +8,8 @@ jobs:
   pypi-publish:
     name: Publish tagged release on PyPI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.11
@@ -15,25 +17,8 @@ jobs:
       with:
         python-version: '3.11'
     - name: Install pypa/build
-      run: >-
-        python -m
-        pip install
-        build
-        --user
+      run: python -m pip install build --user
     - name: Build a binary wheel and a source tarball
-      run: >-
-        python -m
-        build
-        --sdist
-        --wheel
-        --outdir dist/
-        .
-    - name: Publish distribution package to PyPI (test)
+      run: python -m build --sdist --wheel --outdir dist/ .
+    - name: Publish distribution package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-    - name: Publish distribution package to PyPI (production)
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Removes the test PyPI publish step (broken — `TEST_PYPI_API_TOKEN` expired/invalid, causing 400 errors)
- Switches from token-based auth (`PYPI_API_TOKEN`) to OIDC trusted publishing (no secrets needed)
- Adds `permissions: id-token: write` required for OIDC

### Prerequisites
A repo owner needs to configure trusted publishing on PyPI:
1. Go to https://pypi.org/manage/project/epytope/settings/publishing/
2. Add a new publisher: GitHub, owner=`KohlbacherLab`, repo=`epytope`, workflow=`pypi-publish.yml`, environment=(leave blank)

### Why
The current workflow failed on the v4.0.0 release ([run](https://github.com/KohlbacherLab/epytope/actions/runs/23849145362)) because the test PyPI token is invalid. OIDC trusted publishing eliminates token management entirely.