### PR TITLE
Bump version to 4.0.1 and finalize changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v4.0.1 - 2026-06-11
 
 ### `Fixed`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "epytope"
-version = "4.0.0"
+version = "4.0.1"
 description = "A Framework for Epitope Detection and Vaccine Design"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Release prep for **4.0.1** (patch).

- Bump `version` 4.0.0 → 4.0.1 in `pyproject.toml`.
- Finalize CHANGELOG: rename `## Unreleased` → `## v4.0.1 - 2026-06-11`.

4.0.1 contains the `EnsemblRESTAdapter` fail-loud + client-side rate-limiting fix (#118 / #117) — the only change on `develop` since 4.0.0.

Merge this, then the `develop → main` "Release 4.0.1" PR follows.